### PR TITLE
Update workspaces.el to make other workspaces persist

### DIFF
--- a/modules/ui/workspaces/autoload/workspaces.el
+++ b/modules/ui/workspaces/autoload/workspaces.el
@@ -118,7 +118,7 @@ Returns t on success, nil otherwise."
   (unless (+workspace-exists-p name)
     (error "'%s' is an invalid workspace" name))
   (let ((fname (expand-file-name +workspaces-data-file persp-save-dir)))
-    (persp-save-to-file-by-names fname *persp-hash* (list name))
+    (persp-save-to-file-by-names fname *persp-hash* (list name) t)
     (and (member name (persp-list-persp-names-in-file fname))
          t)))
 


### PR DESCRIPTION
It appear this morning as a bug and it turns out that `persp-save-to-file-by-names` has an optional argument keep-others which in this case should be set to t I believe as other workspaces should persist as the default behaviour, but it did not seem to be and  I believe I did not change the source by chance and so came back to submit a PR